### PR TITLE
Add like button to the design page

### DIFF
--- a/app/assets/stylesheets/framework/buttons.scss
+++ b/app/assets/stylesheets/framework/buttons.scss
@@ -19,6 +19,11 @@
   }
 }
 
+.btn-grayish-navy {
+  color: $white;
+  background-color: #525f7f;
+}
+
 .no-outline {
 
   &:focus,

--- a/app/assets/stylesheets/framework/common.scss
+++ b/app/assets/stylesheets/framework/common.scss
@@ -70,11 +70,15 @@
 }
 
 .inline-list > li {
-    display: inline-block;
+  display: inline-block;
+
+  &:empty {
+    display: none;
+  }
 }
 
 .inline-list li:last-child {
-    margin-right: 0;
+  margin-right: 0;
 }
 .inline-list li a {
     display: block;

--- a/app/assets/stylesheets/pages/design.scss
+++ b/app/assets/stylesheets/pages/design.scss
@@ -92,6 +92,20 @@ a.thumb{
       display: table-cell;
       vertical-align: top;
     }
+
+    .actionbar {
+      display: flex;
+      align-items: flex-end;
+      margin-bottom: .5rem;
+    }
+
+    .actionbar-left {
+      float: left;
+      flex: 1;
+    }
+    .actionbar-right{
+      float: right;
+    }
 }
 
 .design-infos{

--- a/app/controllers/designs_controller.rb
+++ b/app/controllers/designs_controller.rb
@@ -22,7 +22,8 @@ class DesignsController < ApplicationController
                                       fields: { blueprint: file_preview_fields })
                                  .serialize
 
-    @page_views_count = Ahoy::Event.where_event('Viewed design', design_id: design.id).count
+    @page_views_count = Ahoy::Event.where_event(Ahoy::Event::VIEWED_DESIGN,
+                                                design_id: design.id).count
 
     Designs::PageViews::AfterPageViewService.new(design, current_user, controller: self).execute
   end

--- a/app/controllers/designs_controller.rb
+++ b/app/controllers/designs_controller.rb
@@ -5,7 +5,7 @@ class DesignsController < ApplicationController
   include AhoyActions
 
   before_action :authenticate_user!, except: %i[show latest popular]
-  before_action :design, only: %i[show edit update destroy download]
+  before_action :design, only: %i[show edit update destroy download like]
 
   def new
     @design = Design.new
@@ -70,6 +70,10 @@ class DesignsController < ApplicationController
                                                  controller: self).execute
 
     render json: { url: url }, status: :ok
+  end
+
+  def like
+    Designs::Likes::AfterLikeService.new(design, current_user, controller: self).execute
   end
 
   def latest

--- a/app/helpers/designs_helper.rb
+++ b/app/helpers/designs_helper.rb
@@ -21,4 +21,10 @@ module DesignsHelper
 
     JSON.parse(design_list)
   end
+
+  def liked_design?(design_id)
+    return false unless current_user
+
+    Ahoy::Event.cached_any_events_for?(Ahoy::Event::LIKED_DESIGN, current_user, design_id: design_id)
+  end
 end

--- a/app/javascript/like_button/components/like_button.vue
+++ b/app/javascript/like_button/components/like_button.vue
@@ -1,0 +1,66 @@
+<script>
+import { mapActions, mapState } from 'vuex';
+
+export default {
+  name: 'LikeButton',
+  props: {
+    likeCssClass: {
+      type: String,
+      required: true,
+    },
+    unlikeCssClass: {
+      type: String,
+      required: true,
+    },
+    likeText: {
+      type: String,
+      required: true,
+    },
+    unlikeText: {
+      type: String,
+      required: true,
+    },
+    likedStatus: {
+      type: Boolean,
+      required: true,
+    },
+    endpoint: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    ...mapState(['liked']),
+    buttonText() {
+      return this.liked ? this.unlikeText : this.likeText;
+    },
+    buttonCssClass() {
+      return this.liked ? this.unlikeCssClass : this.likeCssClass;
+    },
+  },
+  created() {
+    this.setLiked(this.likedStatus);
+  },
+  methods: {
+    ...mapActions(['createNewLike', 'deleteLike', 'setLiked']),
+    actionButtonClicked() {
+      if (this.liked) {
+        return this.deleteLike({ endpoint: this.endpoint });
+      }
+
+      return this.createNewLike({ endpoint: this.endpoint });
+    },
+  },
+};
+</script>
+
+<template>
+  <div>
+    <button :class="buttonCssClass" @click="actionButtonClicked">
+      <span>
+        <i class="fas fa-lg fa-heart"></i>
+      </span>
+      <span class="btn-inner--text">{{ buttonText }}</span>
+    </button>
+  </div>
+</template>

--- a/app/javascript/like_button/store/actions.js
+++ b/app/javascript/like_button/store/actions.js
@@ -1,0 +1,49 @@
+import axios from 'lib/utils/axios_utils';
+import eventHub from 'page_counters/components/event_hub';
+import * as types from './mutation_types';
+
+export const setLiked = ({ commit }, liked) => commit(types.SET_LIKED, liked);
+
+export const receiveDeleteLikeError = ({ dispatch }, payload) => {
+  // TODO: post error
+};
+
+export const receiveDeleteLike = ({ dispatch }) => {
+  dispatch('setLiked', false);
+
+  eventHub.$emit('unlike');
+};
+
+export const deleteLike = ({ dispatch }, payload) => {
+  axios
+    .delete(payload.endpoint)
+    .then(response => {
+      dispatch('receiveDeleteLike');
+    })
+    .catch(error => {
+      const errorPayload = Object.assign(payload, { error });
+      dispatch('receiveDeleteLikeError', errorPayload);
+    });
+};
+
+export const receiveCreateLikeError = ({ dispatch }, payload) => {
+  // TODO: post error
+};
+
+export const receiveCreateLike = ({ dispatch }) => {
+  dispatch('setLiked', true);
+
+  eventHub.$emit('like');
+};
+
+export const createNewLike = ({ dispatch }, payload) => {
+  axios
+    .post(payload.endpoint)
+    .then(response => {
+      dispatch('receiveCreateLike');
+    })
+    .catch(error => {
+      const errorPayload = Object.assign(payload, { error });
+      dispatch('receiveCreateLikeError', errorPayload);
+    });
+};

--- a/app/javascript/like_button/store/index.js
+++ b/app/javascript/like_button/store/index.js
@@ -1,0 +1,16 @@
+import Vue from 'vue/dist/vue.esm';
+import Vuex from 'vuex';
+import * as actions from './actions';
+import mutations from './mutations';
+import state from './state';
+
+Vue.use(Vuex);
+
+export default function createStore() {
+  return new Vuex.Store({
+    actions,
+    mutations,
+    state: state(),
+    strict: process.env.NODE_ENV !== 'production',
+  });
+};

--- a/app/javascript/like_button/store/mutation_types.js
+++ b/app/javascript/like_button/store/mutation_types.js
@@ -1,0 +1,1 @@
+export const SET_LIKED = 'SET_LIKED';

--- a/app/javascript/like_button/store/mutations.js
+++ b/app/javascript/like_button/store/mutations.js
@@ -1,0 +1,7 @@
+import * as types from './mutation_types';
+
+export default {
+  [types.SET_LIKED](state, liked) {
+    Object.assign(state, { liked });
+  },
+};

--- a/app/javascript/like_button/store/state.js
+++ b/app/javascript/like_button/store/state.js
@@ -1,0 +1,3 @@
+export default () => ({
+  liked: false,
+});

--- a/app/javascript/page_counters/components/downloads_counter.vue
+++ b/app/javascript/page_counters/components/downloads_counter.vue
@@ -6,17 +6,6 @@ import eventHub from './event_hub';
 export default {
   name: 'DownloadsCounter',
   mixins: [counterMixin],
-  props: {
-    min: {
-      type: Number,
-      required: true,
-    },
-  },
-  computed: {
-    showCounter() {
-      return this.count >= this.min;
-    },
-  },
   created() {
     eventHub.$on('download', this.incrementCounter);
   },
@@ -27,10 +16,10 @@ export default {
     ...mapActions(['setDownloadsCount']),
     incrementCounter() {
       let downloadsCount = this.count;
-      this.setDownloadsCount(downloadsCount += 1);
+      this.setDownloadsCount((downloadsCount += 1));
     },
-  }
-}
+  },
+};
 </script>
 <template>
   <span v-if="showCounter" data-toggle="tooltip" data-placement="bottom" :title="counterTooltip">

--- a/app/javascript/page_counters/components/likes_counter.vue
+++ b/app/javascript/page_counters/components/likes_counter.vue
@@ -1,0 +1,35 @@
+<script>
+import counterMixin from 'page_counters/mixins/counter_mixin';
+import { mapActions } from 'vuex';
+import eventHub from './event_hub';
+
+export default {
+  name: 'LikesCounter',
+  mixins: [counterMixin],
+  created() {
+    eventHub.$on('like', this.incrementCounter);
+    eventHub.$on('unlike', this.decrementCounter);
+  },
+  beforeDestroy() {
+    eventHub.$off('like', this.incrementCounter);
+    eventHub.$off('unlike', this.decrementCounter);
+  },
+  methods: {
+    ...mapActions(['setLikesCount']),
+    incrementCounter() {
+      let likesCount = this.count;
+      this.setLikesCount((likesCount += 1));
+    },
+    decrementCounter() {
+      let likesCount = this.count;
+      this.setLikesCount((likesCount -= 1));
+    },
+  },
+};
+</script>
+<template>
+  <span v-if="showCounter" data-toggle="tooltip" data-placement="bottom" :title="counterTooltip">
+    <i class="fas fa-heart mr-1"></i>
+    {{ localeCount }}
+  </span>
+</template>

--- a/app/javascript/page_counters/components/page_counters.vue
+++ b/app/javascript/page_counters/components/page_counters.vue
@@ -1,6 +1,7 @@
 <script>
 import ViewsCounter from 'page_counters/components/views_counter.vue';
 import DownloadsCounter from 'page_counters/components/downloads_counter.vue';
+import LikesCounter from 'page_counters/components/likes_counter.vue';
 import { numberToLocale } from 'lib/utils/number_utils';
 import { mapState, mapActions } from 'vuex';
 
@@ -9,6 +10,7 @@ export default {
   components: {
     ViewsCounter,
     DownloadsCounter,
+    LikesCounter,
   },
   props: {
     views: {
@@ -21,37 +23,39 @@ export default {
       default: () => ({}),
       required: false,
     },
+    likes: {
+      type: Object,
+      default: () => ({}),
+      required: false,
+    },
     locale: {
       type: String,
       required: true,
     },
   },
   computed: {
-    ...mapState(['downloadsCount']),
-    viewsCount() {
-      return this.views.count;
-    },
+    ...mapState(['downloadsCount', 'likesCount']),
     viewsLocaleCount() {
-      return numberToLocale(this.viewsCount, this.locale);
+      return numberToLocale(this.views.count, this.locale);
     },
     downloadsLocaleCount() {
       return numberToLocale(this.downloadsCount, this.locale);
     },
-    hasPageView() {
-      return this.objectNotEmpty(this.views) &&
-             this.viewsCount >= this.views.min
-    },
-    hasDownload() {
-      return this.objectNotEmpty(this.downloads)
+    likesLocaleCount() {
+      return numberToLocale(this.likesCount, this.locale);
     },
   },
   created() {
     this.setDownloadsCount(this.downloads.count);
+    this.setLikesCount(this.likes.count);
   },
   methods: {
-    ...mapActions(['setDownloadsCount']),
+    ...mapActions(['setDownloadsCount', 'setLikesCount']),
     objectNotEmpty(obj) {
-      return Object.keys(obj).length !== 0
+      return Object.keys(obj).length !== 0;
+    },
+    hasCounter(counter) {
+      return this.objectNotEmpty(counter);
     },
   },
 };
@@ -59,15 +63,25 @@ export default {
 
 <template>
   <ul class="inline-list inline-list--spaced">
-    <li v-if="hasPageView">
+    <li v-if="hasCounter(views)">
       <views-counter
-        :count="viewsCount"
+        :count="views.count"
         :locale-count="viewsLocaleCount"
+        :min="views.min"
         :text-plural="views.textPlural"
         :text-singular="views.textSingular"
       />
     </li>
-    <li v-if="hasDownload">
+    <li v-if="hasCounter(likes)">
+      <likes-counter
+        :count="likesCount"
+        :locale-count="likesLocaleCount"
+        :min="likes.min"
+        :text-plural="likes.textPlural"
+        :text-singular="likes.textSingular"
+      />
+    </li>
+    <li v-if="hasCounter(downloads)">
       <downloads-counter
         :count="downloadsCount"
         :locale-count="downloadsLocaleCount"

--- a/app/javascript/page_counters/components/views_counter.vue
+++ b/app/javascript/page_counters/components/views_counter.vue
@@ -1,12 +1,13 @@
 <script>
 import counterMixin from 'page_counters/mixins/counter_mixin';
+
 export default {
   name: 'ViewsCounter',
   mixins: [counterMixin],
-}
+};
 </script>
 <template>
-  <span data-toggle="tooltip" data-placement="bottom" :title="counterTooltip">
+  <span v-if="showCounter" data-toggle="tooltip" data-placement="bottom" :title="counterTooltip">
     <i class="far fa-eye mr-1"></i>
     {{ localeCount }}
   </span>

--- a/app/javascript/page_counters/mixins/counter_mixin.js
+++ b/app/javascript/page_counters/mixins/counter_mixin.js
@@ -10,6 +10,10 @@ export default {
       type: String,
       required: true,
     },
+    min: {
+      type: Number,
+      required: true,
+    },
     textPlural: {
       type: String,
       required: true,
@@ -27,11 +31,17 @@ export default {
       template: '<div class="tooltip counter-tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
     });
   },
+  beforeDestroy() {
+    $('[data-toggle="tooltip"]').tooltip('destroy');
+  },
   computed: {
     counterTooltip() {
       if (this.count !== 1) return this.textPlural;
 
       return this.textSingular;
+    },
+    showCounter() {
+      return this.count >= this.min;
     },
   },
 }

--- a/app/javascript/page_counters/store/actions.js
+++ b/app/javascript/page_counters/store/actions.js
@@ -2,4 +2,5 @@ import * as types from './mutation_types';
 
 export const setDownloadsCount = ({ commit }, count) => commit(types.SET_DOWNLOADS_COUNT, count);
 
+export const setLikesCount = ({ commit }, count) => commit(types.SET_LIKES_COUNT, count);
 

--- a/app/javascript/page_counters/store/mutation_types.js
+++ b/app/javascript/page_counters/store/mutation_types.js
@@ -1,1 +1,3 @@
 export const SET_DOWNLOADS_COUNT = 'SET_DOWNLOADS_COUNT';
+
+export const SET_LIKES_COUNT = 'SET_LIKES_COUNT';

--- a/app/javascript/page_counters/store/mutations.js
+++ b/app/javascript/page_counters/store/mutations.js
@@ -4,4 +4,8 @@ export default {
   [types.SET_DOWNLOADS_COUNT](state, downloadsCount) {
     Object.assign(state, { downloadsCount });
   },
+
+  [types.SET_LIKES_COUNT](state, likesCount) {
+    Object.assign(state, { likesCount });
+  },
 };

--- a/app/javascript/page_counters/store/state.js
+++ b/app/javascript/page_counters/store/state.js
@@ -1,3 +1,4 @@
 export default () => ({
   downloadsCount: 0,
+  likesCount: 0,
 });

--- a/app/javascript/pages/designs/index.js
+++ b/app/javascript/pages/designs/index.js
@@ -3,9 +3,11 @@ import Vue from 'vue/dist/vue.esm';
 import ContentPreview from 'content_preview/components/content_preview.vue';
 import ContentPreviewToggleButton from 'content_preview/components/content_preview_toggle_button.vue';
 import DownloadButton from 'download_button/components/download_button.vue';
+import LikeButton from 'like_button/components/like_button.vue';
 import PageCounters from 'page_counters/components/page_counters.vue';
 import createContentPreviewStore from 'content_preview/store';
 import createDownloadButtonStore from 'download_button/store';
+import createLikeButtonStore from 'like_button/store';
 import createPageCountersStore from 'page_counters/store';
 import ActionCableVue from 'actioncable-vue';
 
@@ -18,13 +20,26 @@ Vue.use(ActionCableVue, {
 });
 
 document.addEventListener('turbolinks:load', () => {
+  const contentPreviewStore = createContentPreviewStore()
+
+  const $contentPreviewToggleButtons = document.getElementsByClassName('js-content-preview-toggle-button');
+  if ($contentPreviewToggleButtons.length > 0) {
+    Array.from($contentPreviewToggleButtons).forEach($contentPreviewToggleButton => {
+      const app = new Vue({
+        el: $contentPreviewToggleButton,
+        store: contentPreviewStore,
+        components: { ContentPreviewToggleButton },
+      });
+    });
+  }
+
   const $contentPreviews = document.getElementsByClassName('js-content-preview');
   if ($contentPreviews.length > 0) {
     Array.from($contentPreviews).forEach($contentPreview => {
       const app = new Vue({
         el: $contentPreview,
-        store: createContentPreviewStore(),
-        components: { ContentPreview, ContentPreviewToggleButton },
+        store: contentPreviewStore,
+        components: { ContentPreview },
       });
     });
   }
@@ -36,6 +51,17 @@ document.addEventListener('turbolinks:load', () => {
         el: $downloadButton,
         store: createDownloadButtonStore(),
         components: { DownloadButton },
+      });
+    });
+  }
+
+  const $likeButtons = document.getElementsByClassName('js-like-button');
+  if ($likeButtons.length > 0) {
+    Array.from($likeButtons).forEach($likeButton => {
+      const app = new Vue({
+        el: $likeButton,
+        store: createLikeButtonStore(),
+        components: { LikeButton },
       });
     });
   }

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -33,6 +33,9 @@ module Ahoy
     counter_culture :design, column_name: proc { |model|
       model.name == 'Downloaded design' ? 'downloads_count' : nil
     }
+    counter_culture :design, column_name: proc { |model|
+      model.name == 'Liked design' ? 'likes_count' : nil
+    }
 
     class << self
       def cached_any_events_for?(event_name, user, event_properties)

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -18,12 +18,31 @@ module Ahoy
 
     self.table_name = 'ahoy_events'
 
+    LIKED_DESIGN = 'Liked design'
+    DOWNLOADED_DESIGN = 'Downloaded design'
+
+    USER_EVENTS = [LIKED_DESIGN, DOWNLOADED_DESIGN].freeze
+
     belongs_to :visit
     belongs_to :user, optional: true
+    counter_culture :user, column_name: proc { |model|
+      (USER_EVENTS.include? model.name) ? 'events_count' : nil
+    }, touch: 'updated_at'
 
     belongs_to :design, class_name: 'Design', store: :properties, optional: true
     counter_culture :design, column_name: proc { |model|
       model.name == 'Downloaded design' ? 'downloads_count' : nil
     }
+
+    class << self
+      def cached_any_events_for?(event_name, user, event_properties)
+        event_fk, event_id = event_properties.first
+
+        cache_name = "any_events_for-#{event_name.parameterize.underscore}-#{event_id}-#{user.updated_at}"
+        Rails.cache.fetch(cache_name, expires_in: 1.week) do
+          Ahoy::Event.where(name: event_name, properties: event_properties, user_id: user.id).any?
+        end
+      end
+    end
   end
 end

--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -18,6 +18,7 @@ module Ahoy
 
     self.table_name = 'ahoy_events'
 
+    VIEWED_DESIGN = 'Viewed design'
     LIKED_DESIGN = 'Liked design'
     DOWNLOADED_DESIGN = 'Downloaded design'
 
@@ -31,10 +32,10 @@ module Ahoy
 
     belongs_to :design, class_name: 'Design', store: :properties, optional: true
     counter_culture :design, column_name: proc { |model|
-      model.name == 'Downloaded design' ? 'downloads_count' : nil
+      model.name == DOWNLOADED_DESIGN ? 'downloads_count' : nil
     }
     counter_culture :design, column_name: proc { |model|
-      model.name == 'Liked design' ? 'likes_count' : nil
+      model.name == LIKED_DESIGN ? 'likes_count' : nil
     }
 
     class << self

--- a/app/models/design.rb
+++ b/app/models/design.rb
@@ -39,9 +39,9 @@ class Design < ApplicationRecord
   has_one :design_downloads, dependent: :destroy
 
   # OPTIONAL
-  # has_many :view_events, -> { where(name: 'Viewed design') },
+  # has_many :view_events, -> { where(name: Ahoy::Event::VIEWED_DESIGN) },
   #          class_name: 'Ahoy::Event', foreign_store: :properties
-  # has_many :download_events, -> { where(name: 'Downloaded design') },
+  # has_many :download_events, -> { where(name: Ahoy::Event::DOWNLOADED_DESIGN) },
   #          class_name: 'Ahoy::Event', foreign_store: :properties
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,7 @@ class User < ApplicationRecord
          email_regexp: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
   has_many :designs
+  has_many :events, class_name: 'Ahoy::Event', dependent: :destroy
 
   # Virtual attribute for authenticating by either username or email
   attr_accessor :login
@@ -51,10 +52,10 @@ class User < ApplicationRecord
                        uniqueness: { case_sensitive: false },
                        length: { in: 3..30 }
 
-  validates_confirmation_of :password
+  validates :password, confirmation: true
   # Only allow letter, number, underscore, hyphen and punctuation.
-  validates_format_of :username,
-                      with: /\A(?:[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\.][a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\-\.]*[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\-]|[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_])\z/
+  validates :username,
+            format: { with: /\A(?:[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\.][a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\-\.]*[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_\-]|[a-zA-ZğüşıöçĞÜŞİÖÇ0-9_])\z/ }
 
   class << self
     # Devise method overridden to allow sign in with email or username

--- a/app/services/designs/downloads/after_download_service.rb
+++ b/app/services/designs/downloads/after_download_service.rb
@@ -23,7 +23,7 @@ module Designs
 
       def perform
         ::AhoyEventService.new(current_user: current_user,
-                               event_name: 'Downloaded design',
+                               event_name: event_name,
                                properties: event_properties,
                                visit_token: params[:visit_token]).track
 
@@ -33,6 +33,10 @@ module Designs
       end
 
       private
+
+      def event_name
+        Ahoy::Event::DOWNLOADED_DESIGN
+      end
 
       def event_properties
         { design_id: design.id }

--- a/app/services/designs/likes/after_like_service.rb
+++ b/app/services/designs/likes/after_like_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Designs
+  module Likes
+    class AfterLikeService
+      attr_reader :current_user, :controller, :params
+      attr_accessor :design
+
+      def initialize(design, user = nil, params = {})
+        @design = design
+        @current_user = user
+        @controller = params.delete(:controller)
+        @params = params.dup
+      end
+
+      def execute
+        controller.ensure_new_visit_created_before_ahoy_async_jobs if controller.present?
+
+        DesignAfterLikeWorker.perform_async(design.id, current_user.id, ahoy.visit_token)
+      end
+
+      def perform
+        return delete_like if liked?
+
+        create_new_like
+      end
+
+      private
+
+      def liked?
+        Ahoy::Event.cached_any_events_for?(event_name, current_user, event_properties)
+      end
+
+      def delete_like
+        Ahoy::Event.where(name: event_name, properties: event_properties, user_id: current_user.id).destroy_all
+      end
+
+      def create_new_like
+        ::AhoyEventService.new(current_user: current_user,
+                               event_name: event_name,
+                               properties: event_properties,
+                               visit_token: params[:visit_token]).track
+      end
+
+      def event_name
+        Ahoy::Event::LIKED_DESIGN
+      end
+
+      def event_properties
+        { design_id: design.id }
+      end
+
+      def ahoy
+        @ahoy ||= controller.present? ? controller.ahoy : service_ahoy
+      end
+
+      def service_ahoy
+        ::Ahoy::Tracker.new(controller: nil, user: current_user)
+      end
+    end
+  end
+end

--- a/app/services/designs/page_views/after_page_view_service.rb
+++ b/app/services/designs/page_views/after_page_view_service.rb
@@ -14,7 +14,7 @@ module Designs
       end
 
       def execute
-        ahoy.track 'Viewed design', design_id: design.id
+        ahoy.track Ahoy::Event::VIEWED_DESIGN, design_id: design.id
 
         PopularityScoreService.new(design).execute
       end

--- a/app/views/designs/show.html.haml
+++ b/app/views/designs/show.html.haml
@@ -40,7 +40,7 @@
       .d-flex.mb-2
         .ml-auto
           .js-page-counters{ data: { behavior: 'vue' } }
-            %page-counters.page-counters{ ':views': { count: @page_views_count,  min: 0, textPlural: 'Toplam Görüntülenme', textSingular: 'Toplam Görüntülenme' }.to_json, ':downloads': { count: @design.downloads_count, min: 1, textPlural: 'İndirme', textSingular: 'İndirme' }.to_json, locale: I18n.locale }
+            %page-counters.page-counters{ ':views': { count: @page_views_count,  min: 0, textPlural: 'Toplam Görüntülenme', textSingular: 'Toplam Görüntülenme' }.to_json, ':downloads': { count: @design.downloads_count, min: 1, textPlural: 'İndirme', textSingular: 'İndirme' }.to_json, ':likes': { count: @design.likes_count, min: 1, textPlural: 'Beğeni', textSingular: 'Beğeni' }.to_json, locale: I18n.locale }
       %h6.text-primary.mt-3 3D Model Açıklama
       .rich.content= simple_format(@design.description)
       %h6.text-primary.mt-3 3D Baskı Ayarları

--- a/app/views/designs/show.html.haml
+++ b/app/views/designs/show.html.haml
@@ -15,8 +15,12 @@
 
   .design
     .design-photos
+      .actionbar
+        .js-content-preview-toggle-button.actionbar-left{ data: { behavior: 'vue' } }
+          %content-preview-toggle-button{ 'css-class': 'btn-xs btn-outline-primary no-outline' }
+        .js-like-button.actionbar-right{ data: { behavior: 'vue' } }
+          %like-button{ 'like-css-class': 'btn-xs btn-primary no-outline border-solid btn-icon', 'unlike-css-class': 'btn-xs btn-grayish-navy no-outline border-solid btn-icon', 'like-text': 'BEĞEN', 'unlike-text': 'BEĞENDİN', ':liked-status': liked_design?(@design.id), 'endpoint': design_like_path(@design) }
       .js-content-preview{ data: { behavior: 'vue' } }
-        %content-preview-toggle-button.mb-2{ 'css-class': 'btn-xs btn-outline-primary no-outline' }
         %content-preview{ 'data-type': 'illustration', 'content-type': 'image',
           ':files': @illustrations, 'toggle-button-text': 'Fotoğraflar',
           'default-thumb-url': image_path('B4B4B4-1.png'), ':active': true,
@@ -30,7 +34,7 @@
       .d-flex.mb-3
         .ml-auto
           .js-download-button{ data: { behavior: 'vue' } }
-            %download-button{ 'css-class': 'btn-xs btn-primary border-solid border-width-15x btn-icon', 'text': t('helpers.button.download'),
+            %download-button{ 'css-class': 'btn-xs btn-primary no-outline border-solid border-width-15x btn-icon', 'text': t('helpers.button.download'),
             'downloading-text': t('helpers.button.downloading'),
             'record-id': @design.id, 'endpoint': design_download_path(@design) }
       .d-flex.mb-2

--- a/app/workers/design_after_like_worker.rb
+++ b/app/workers/design_after_like_worker.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class DesignAfterLikeWorker
+  include ApplicationWorker
+
+  def perform(design_id, current_user_id, visit_token)
+    design = Design.find(design_id)
+    current_user = User.find(current_user_id)
+
+    Designs::Likes::AfterLikeService.new(design, current_user, visit_token: visit_token).perform
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   get '/3d-model/:category/:id', to: 'designs#show', as: :design_show, constraints: { id: /.*\D+.*/ }
   get '/design/download/:id', to: 'designs#download', as: :design_download, constraints: { id: /.*\D+.*/ }
+  match '/design/like/:id', to: 'designs#like', via: [:post, :delete], as: :design_like, constraints: { id: /.*\D+.*/ }
+
 
   devise_for :users, path: '', controllers: { registrations: :registrations,
                                               passwords: :passwords,

--- a/db/migrate/20191027115750_backfill_gutentag_cache_counter.rb
+++ b/db/migrate/20191027115750_backfill_gutentag_cache_counter.rb
@@ -1,7 +1,9 @@
 class BackfillGutentagCacheCounter < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     Gutentag::Tag.in_batches.update_all taggings_count: 0
   end
+
+  def down; end
 end

--- a/db/migrate/20191114113825_backfill_designs_downloads_count.rb
+++ b/db/migrate/20191114113825_backfill_designs_downloads_count.rb
@@ -1,7 +1,7 @@
 class BackfillDesignsDownloadsCount < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     safety_assured do
       execute <<-SQL.squish
           UPDATE designs
@@ -11,4 +11,6 @@ class BackfillDesignsDownloadsCount < ActiveRecord::Migration[5.2]
       SQL
     end
   end
+
+  def down; end
 end

--- a/db/migrate/20191118143605_backfill_designs_hourly_downloads_count.rb
+++ b/db/migrate/20191118143605_backfill_designs_hourly_downloads_count.rb
@@ -1,7 +1,7 @@
 class BackfillDesignsHourlyDownloadsCount < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     safety_assured do
       execute <<-SQL.squish
           UPDATE designs
@@ -9,4 +9,6 @@ class BackfillDesignsHourlyDownloadsCount < ActiveRecord::Migration[5.2]
       SQL
     end
   end
+
+  def down; end
 end

--- a/db/migrate/20191216080850_backfill_illustrations_large_url_medium_url_and_thumb_url.rb
+++ b/db/migrate/20191216080850_backfill_illustrations_large_url_medium_url_and_thumb_url.rb
@@ -1,10 +1,12 @@
 class BackfillIllustrationsLargeUrlMediumUrlAndThumbUrl < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     Illustration.unscoped.in_batches do |relation|
       relation.update_all large_url: '', medium_url: '', thumb_url: ''
       sleep(0.1)
     end
   end
+
+  def down; end
 end

--- a/db/migrate/20191216123659_backfill_blueprints_thumb_url.rb
+++ b/db/migrate/20191216123659_backfill_blueprints_thumb_url.rb
@@ -1,10 +1,12 @@
 class BackfillBlueprintsThumbUrl < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     Blueprint.unscoped.in_batches do |relation|
       relation.update_all thumb_url: ''
       sleep(0.1)
     end
   end
+
+  def down; end
 end

--- a/db/migrate/20191219111524_backfill_designs_popularity_score.rb
+++ b/db/migrate/20191219111524_backfill_designs_popularity_score.rb
@@ -1,7 +1,7 @@
 class BackfillDesignsPopularityScore < ActiveRecord::Migration[5.2]
   disable_ddl_transaction!
 
-  def change
+  def up
     safety_assured do
       now = Time.current.to_i
 
@@ -11,4 +11,6 @@ class BackfillDesignsPopularityScore < ActiveRecord::Migration[5.2]
       SQL
     end
   end
+
+  def down; end
 end

--- a/db/migrate/20191223105928_add_events_count_to_users.rb
+++ b/db/migrate/20191223105928_add_events_count_to_users.rb
@@ -1,0 +1,10 @@
+class AddEventsCountToUsers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :users, :events_count, :integer
+    change_column_default :users, :events_count, 0
+  end
+
+  def down
+    remove_column :users, :events_count
+  end
+end

--- a/db/migrate/20191223110515_backfill_users_events_count.rb
+++ b/db/migrate/20191223110515_backfill_users_events_count.rb
@@ -1,0 +1,16 @@
+class BackfillUsersEventsCount < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute <<-SQL.squish
+          UPDATE users
+            SET events_count = (SELECT count(*)
+                                  FROM ahoy_events ae
+                                 WHERE  ae.user_id = users.id and ae.name = 'Downloaded design')
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/db/migrate/20191223111318_add_not_null_constraint_to_users_events_count.rb
+++ b/db/migrate/20191223111318_add_not_null_constraint_to_users_events_count.rb
@@ -1,0 +1,7 @@
+class AddNotNullConstraintToUsersEventsCount < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :users, :events_count, false
+  end
+end
+
+

--- a/db/migrate/20191223235921_add_likes_count_to_designs.rb
+++ b/db/migrate/20191223235921_add_likes_count_to_designs.rb
@@ -1,0 +1,10 @@
+class AddLikesCountToDesigns < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :designs, :likes_count, :integer
+    change_column_default :designs, :likes_count, 0
+  end
+
+  def self.down
+    remove_column :designs, :likes_count
+  end
+end

--- a/db/migrate/20191224000201_backfill_designs_likes_count.rb
+++ b/db/migrate/20191224000201_backfill_designs_likes_count.rb
@@ -1,0 +1,16 @@
+class BackfillDesignsLikesCount < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    safety_assured do
+      execute <<-SQL.squish
+          UPDATE designs
+            SET likes_count = (SELECT count(1)
+                                     FROM ahoy_events ae
+                                    WHERE  ae.name = 'Liked design' and ae.properties @> json_build_object('design_id', designs.id)::jsonb)
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/db/migrate/20191224000412_add_not_null_constraint_to_designs_likes_count.rb
+++ b/db/migrate/20191224000412_add_not_null_constraint_to_designs_likes_count.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToDesignsLikesCount < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :designs, :likes_count, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_111318) do
+ActiveRecord::Schema.define(version: 2019_12_24_000412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,7 @@ ActiveRecord::Schema.define(version: 2019_12_23_111318) do
     t.float "hourly_downloads_count", default: 0.0, null: false
     t.float "popularity_score", default: 0.0, null: false
     t.datetime "home_popular_at"
+    t.integer "likes_count", default: 0, null: false
     t.index ["category_id"], name: "index_designs_on_category_id"
     t.index ["slug"], name: "index_designs_on_slug", unique: true
     t.index ["user_id"], name: "index_designs_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_20_200156) do
+ActiveRecord::Schema.define(version: 2019_12_23_111318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -217,6 +217,7 @@ ActiveRecord::Schema.define(version: 2019_12_20_200156) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username"
+    t.integer "events_count", default: 0, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/boyutluseyler/gon_helper.rb
+++ b/lib/boyutluseyler/gon_helper.rb
@@ -4,6 +4,10 @@ module Boyutluseyler
   module GonHelper
     def add_gon_variables
       gon.websocket_server_url = Rails.application.config.websocket_server_url
+      if current_user
+        gon.current_user_id = current_user.id
+        gon.current_username = current_user.username
+      end
     end
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -127,7 +127,7 @@ if Rails.env.development? || Rails.env.test?
 
       p '6/7 Creating Download Events'
 
-      event_name = 'Downloaded design'
+      event_name = Ahoy::Event::DOWNLOADED_DESIGN
       visit_ids = Ahoy::Event.where_event(event_name).pluck(:visit_id)
       Ahoy::Event.where_event(event_name).delete_all
       Ahoy::Visit.delete(visit_ids)
@@ -145,7 +145,7 @@ if Rails.env.development? || Rails.env.test?
 
       p '7/7 Creating Visit Events'
 
-      event_name = 'Viewed design'
+      event_name = Ahoy::Event::VIEWED_DESIGN
       visit_ids = Ahoy::Event.where_event(event_name).pluck(:visit_id)
       Ahoy::Event.where_event(event_name).delete_all
       Ahoy::Visit.delete(visit_ids)


### PR DESCRIPTION
- Create like button component
- Cache user events (`Liked design`, `Downloaded design`)
- Create likes counter component
- Cache design likes count
- Refactor page counters
- Add likes counter to the design page
- Make backfill migrations reversible
- Refactor event names

This closes #54 and closes #56 